### PR TITLE
Add FastAPI backend scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
 # pdf-chat
 
 ## Backend
+The backend uses FastAPI and is located in the `backend` directory. Development is containerized with Docker and dependencies are managed via Poetry.
 
-The backend is a FastAPI application located in the `backend` directory. Package management
-is handled using [uv](https://github.com/astral-sh/uv).
-
-To install dependencies and run the server:
+To start the development server:
 
 ```bash
 cd backend
-uv pip install -e .
-uvicorn main:app --reload
+make up
+```
+
+Run tests and linting:
+
+```bash
+make lint
+make test
 ```
 
 ## Frontend
-
 A placeholder `frontend` directory has been created. The structure will be filled in later.
-
-

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+APP_ENV=local
+LOG_LEVEL=debug

--- a/backend/.github/workflows/ci.yaml
+++ b/backend/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: abatilo/actions-poetry@v2
+      - run: poetry install --no-root --only main,dev
+      - run: make lint test

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.284
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-ujson"]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+RUN groupadd -g 1001 app && \
+    useradd -m -u 1001 -g app app
+
+WORKDIR /code
+
+RUN pip install --no-cache-dir poetry
+COPY pyproject.toml poetry.lock* /code/
+RUN poetry install --no-root --only main,dev
+
+COPY . /code
+
+USER app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,17 @@
+up:
+	docker compose up --build -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f --tail 100
+
+test:
+	poetry run pytest -q
+
+lint:
+	poetry run ruff check app && poetry run mypy app
+
+format:
+	poetry run black .

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,29 @@
+# Backend
+
+This is a FastAPI backend based on the fastapi-nano template.
+
+## Requirements
+- Docker
+- Docker Compose
+- Poetry
+- pre-commit
+
+## Initial Setup
+```bash
+poetry install
+pre-commit install
+```
+
+## Development Server
+```bash
+docker compose up --build
+```
+
+## Testing & Linting
+```bash
+make lint
+make test
+```
+
+## Production Deployment
+Use the provided `Dockerfile` to build and run the application in production.

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def get_health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+from .api.health import router as health_router
+
+app = FastAPI()
+
+app.include_router(health_router)

--- a/backend/app/tests/test_health.py
+++ b/backend/app/tests/test_health.py
@@ -1,0 +1,11 @@
+import pytest
+from httpx import AsyncClient
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_health() -> None:
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        response = await ac.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  backend:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/code
+    env_file:
+      - .env

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,0 @@
-from fastapi import FastAPI
-
-app = FastAPI()
-
-@app.get("/")
-async def read_root():
-    return {"message": "Hello, world!"}
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,12 +1,23 @@
-[project]
+[tool.poetry]
 name = "backend"
 version = "0.1.0"
-dependencies = [
-    "fastapi",
-    "uvicorn"
-]
+description = "FastAPI backend"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "*"
+"uvicorn[standard]" = "*"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+pytest-asyncio = "*"
+ruff = "*"
+black = "*"
+mypy = "*"
+httpx = "*"
 
 [build-system]
-requires = ["uv>=0.1"]
-build-backend = "uv.build"
-
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- bootstrap FastAPI backend with Docker, Poetry, and fastapi-nano layout
- add health endpoint and tests
- configure linting, formatting, typing and CI
- update README with development instructions

## Testing
- `poetry run ruff check app`
- `poetry run mypy app` *(fails: cannot find stub)*
- `poetry run pytest -q` *(fails: command not found)*